### PR TITLE
Standardize Drush usage for teams

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/commands/{$name}": ["type:drupal-drush"]
+            "web/drush/commands/{$name}": ["type:drupal-drush"]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
             "web/core": ["type:drupal-core"],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "web/themes/contrib/{$name}": ["type:drupal-theme"]
+            "web/themes/contrib/{$name}": ["type:drupal-theme"],
+            "drush/commands/{$name}": ["type:drupal-drush"]
         }
     }
 }

--- a/drush/README.md
+++ b/drush/README.md
@@ -1,3 +1,0 @@
-The three subdirectories here hold project-specific commandfiles, site aliases, and configuration for Drush. These will all be included automatically when you use the vendor/bin/dr wrapper script that should be in your project root directory. The dr script intentionally skips loading commands/aliases/config from the typical global locations in order to ensure that all team members have same Drush environment.
- 
- See http://packages.drush.org/ for a directory of Drush commands installable via Composer.

--- a/drush/README.md
+++ b/drush/README.md
@@ -1,3 +1,3 @@
-The three subdirectories here hold project-specific commandfiles, site aliases, and configuration for Drush. These will all be included automatically when you use the ./dr wrapper script that should be in your project root directory. The dr script intentionally skips loading commands/aliases/config from the typical global locations in order to ensure that all team members have same Drush environment.
+The three subdirectories here hold project-specific commandfiles, site aliases, and configuration for Drush. These will all be included automatically when you use the vendor/bin/dr wrapper script that should be in your project root directory. The dr script intentionally skips loading commands/aliases/config from the typical global locations in order to ensure that all team members have same Drush environment.
  
  See http://packages.drush.org/ for a directory of Drush commands installable via Composer.

--- a/drush/README.md
+++ b/drush/README.md
@@ -1,0 +1,3 @@
+The three subdirectories here hold project-specific commandfiles, site aliases, and configuration for Drush. These will all be included automatically when you use the ./dr wrapper script that should be in your project root directory. The dr script intentionally skips loading commands/aliases/config from the typical global locations in order to ensure that all team members have same Drush environment.
+ 
+ See http://packages.drush.org/ for a directory of Drush commands installable via Composer.

--- a/scripts/composer/post-install.sh
+++ b/scripts/composer/post-install.sh
@@ -19,11 +19,3 @@ if [ ! -d web/sites/default/files ]
   then
     mkdir -m777 web/sites/default/files
 fi
-
-# Add wrapper script for launching drush with project specific config/aliases/commands.
-if [ ! -d vendor/bin/dr ]
-  then
-    echo "#!/usr/bin/env sh
-vendor/bin/drush --local --alias-path=drush/site-aliases --config=drush/config --include=drush/commands $@" > vendor/bin/dr
-    chmod +x vendor/bin/dr
-fi

--- a/scripts/composer/post-install.sh
+++ b/scripts/composer/post-install.sh
@@ -21,9 +21,9 @@ if [ ! -d web/sites/default/files ]
 fi
 
 # Add wrapper script for launching drush with project specific config/aliases/commands.
-if [ ! -d dr ]
+if [ ! -d vendor/bin/dr ]
   then
     echo "#!/usr/bin/env sh
-vendor/bin/drush --local --alias-path=drush/site-aliases --config=drush/config --include=drush/commands $@" > dr
-    chmod +x dr
+vendor/bin/drush --local --alias-path=drush/site-aliases --config=drush/config --include=drush/commands $@" > vendor/bin/dr
+    chmod +x vendor/bin/dr
 fi

--- a/scripts/composer/post-install.sh
+++ b/scripts/composer/post-install.sh
@@ -19,3 +19,11 @@ if [ ! -d web/sites/default/files ]
   then
     mkdir -m777 web/sites/default/files
 fi
+
+# Add wrapper script for launching drush with project specific config/aliases/commands.
+if [ ! -d dr ]
+  then
+    echo "#!/usr/bin/env sh
+vendor/bin/drush --local --alias-path=drush/site-aliases --config=drush/config --include=drush/commands $@" > dr
+    chmod +x dr
+fi

--- a/web/drush/README.md
+++ b/web/drush/README.md
@@ -1,0 +1,1 @@
+The three subdirectories here hold project-specific commandfiles, site aliases, and configuration for Drush. See http://packages.drush.org/ for a directory of Drush commands installable via Composer.


### PR DESCRIPTION
1. Add a new installer-path to composer.json so that Drush projects installed via Composer are automatically saved to the correct directory (drush/commands).
2. Add a new Drush top level directory and 3 subdirectories for storing project-specific config, aliases, and commands.
3. During post-install, create a wrapper script called 'dr' which launches drush and points to our new subdirs and skips loading from global locations. I didn't call it 'drush' because the top level directory is already called that and unix disallows a file and directory having same name. An alternative to dr could be drush.sh or dru.sh
