### PR TITLE
Disable xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
 
 before_install:
+  - phpenv config-rm xdebug.ini
   - composer --verbose self-update
   - composer --version
 


### PR DESCRIPTION
Disable xdebug to speed up the unit tests.
