### PR TITLE
Update Drush requirement to "drush/drush":  "8.*"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "composer/installers": "^1.0.20",
         "drupal/core": "8.0.*",
-        "drush/drush": "7.0.x-dev",
+        "drush/drush": "8.*",
 
         "drupal/devel": "8.1.*@dev",
         "drupal/token": "8.1.*@dev"


### PR DESCRIPTION
Drush now has a 7.x branch, and 'master' is labeled '8.x-dev'.  In composer.json, we therefore now need to require drush/drush 8.\* to get the version that is compatible with Drupal 8.
