### PR TITLE
Keep `web/` up to date

### DIFF
--- a/scripts/drupal/update-scaffold
+++ b/scripts/drupal/update-scaffold
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT=`realpath "${CWD}/../.."`
+
+drush dl drupal-8 --destination=/tmp --drupal-project-rename=drupal-8 --quiet -y
+
+rsync -avz --delete /tmp/drupal-8/ $ROOT/web \
+ --exclude=.gitkeep \
+ --exclude=autoload.php \
+ --exclude=composer.json \
+ --exclude=core \
+ --exclude=drush \
+ --exclude=example.gitignore \
+ --exclude=LICENSE.txt \
+ --exclude=README.txt \
+ --exclude=vendor
+
+rm -rf /tmp/drupal-8
+

--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -5,3 +5,4 @@ sites/**/files/**/*
 libraries/**/*
 sites/**/libraries/**/*
 profiles/**/libraries/**/*
+**/js_test_files/**/*

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -21,7 +21,9 @@
     "comma-style": [2, "last"],
     "eqeqeq": [2, "smart"],
     "guard-for-in": 2,
+    "indent": [2, 2, {"indentSwitchCase": true}],
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
+    "lines-around-comment": [2, {"beforeBlockComment": true, "afterBlockComment": false}],
     "no-implied-eval": 2,
     "no-mixed-spaces-and-tabs": 2,
     "no-nested-ternary": 2,
@@ -30,15 +32,24 @@
     "no-undef": 2,
     "no-undefined": 2,
     "no-unused-vars": [2, {"vars": "local", "args": "none"}],
+    "one-var": [2, "never"],
     "semi": [2, "always"],
-    "space-after-keywords": [2, "always", {"checkFunctionKeyword": true}],
+    "space-after-keywords": [2, "always"],
     "space-before-blocks": [2, "always"],
+    "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
     "space-in-brackets": [2, "never"],
     "space-in-parens": [2, "never"],
     "spaced-line-comment": [2, "always"],
     "strict": 2,
     // Warnings.
     "max-nested-callbacks": [1, 3],
+    "valid-jsdoc": [1, {
+      "prefer": {
+        "returns": "return",
+        "property": "prop"
+      },
+      "requireReturn": false
+    }],
     // Disabled.
     "camelcase": 0,
     "consistent-return": 0,

--- a/web/.gitattributes
+++ b/web/.gitattributes
@@ -1,6 +1,6 @@
 # Drupal git normalization
-# @see http://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
-# @see http://drupal.org/node/1542048
+# @see https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+# @see https://www.drupal.org/node/1542048
 
 # Normally these settings would be done with macro attributes for improved
 # readability and easier maintenance. However macros can only be defined at the
@@ -50,3 +50,4 @@
 *.jpg     -text diff
 *.png     -text diff
 *.phar    -text diff
+*.exe     -text diff

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -3,7 +3,7 @@
 #
 
 # Protect files and directories from prying eyes.
-<FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\..*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
+<FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\..*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
   <IfModule mod_authz_core.c>
     Require all denied
   </IfModule>
@@ -24,6 +24,10 @@ ErrorDocument 404 /index.php
 # Set the default handler.
 DirectoryIndex index.php index.html index.htm
 
+# Add correct encoding for SVGZ.
+AddType image/svg+xml svg svgz
+AddEncoding gzip svgz
+
 # Override PHP settings that cannot be changed at runtime. See
 # sites/default/default.settings.php and
 # Drupal\Core\DrupalKernel::bootEnvironment() for settings that can be
@@ -35,6 +39,9 @@ DirectoryIndex index.php index.html index.htm
   php_value mbstring.http_input             pass
   php_value mbstring.http_output            pass
   php_flag mbstring.encoding_translation    off
+  # PHP 5.6 has deprecated $HTTP_RAW_POST_DATA and produces warnings if this is
+  # not set.
+  php_value always_populate_raw_post_data   -1
 </IfModule>
 
 # Requires mod_expires to be enabled.
@@ -90,14 +97,14 @@ DirectoryIndex index.php index.html index.htm
   # URL, either WITH or WITHOUT the 'www.' prefix. Choose ONLY one option:
   #
   # To redirect all users to access the site WITH the 'www.' prefix,
-  # (http://example.com/... will be redirected to http://www.example.com/...)
+  # (http://example.com/foo will be redirected to http://www.example.com/foo)
   # uncomment the following:
   # RewriteCond %{HTTP_HOST} .
   # RewriteCond %{HTTP_HOST} !^www\. [NC]
   # RewriteRule ^ http%{ENV:protossl}://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
   #
   # To redirect all users to access the site WITHOUT the 'www.' prefix,
-  # (http://www.example.com/... will be redirected to http://example.com/...)
+  # (http://www.example.com/foo will be redirected to http://example.com/foo)
   # uncomment the following:
   # RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
   # RewriteRule ^ http%{ENV:protossl}://%1%{REQUEST_URI} [L,R=301]
@@ -132,13 +139,14 @@ DirectoryIndex index.php index.html index.htm
   # Allow access to PHP files in /core (like authorize.php or install.php):
   RewriteCond %{REQUEST_URI} !/core/[^/]*\.php$
   # Allow access to test-specific PHP files:
-  RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?.php$
+  RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?.php
   # Allow access to Statistics module's custom front controller.
   # Copy and adapt this rule to directly execute PHP files in contributed or
   # custom modules or to run another PHP application in the same directory.
   RewriteCond %{REQUEST_URI} !/core/modules/statistics/statistics.php$
   # Deny access to any other PHP files that do not match the rules above.
-  RewriteRule "^.+/.*\.php$" - [F]
+  # Specifically, disallow autoload.php from being served directly.
+  RewriteRule "^(.+/.*|autoload)\.php($|/)" - [F]
 
   # Rules to correctly serve gzip compressed CSS and JS files.
   # Requires both mod_rewrite and mod_headers to be enabled.

--- a/web/index.php
+++ b/web/index.php
@@ -9,37 +9,14 @@
  */
 
 use Drupal\Core\DrupalKernel;
-use Drupal\Core\Site\Settings;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 $autoloader = require_once 'autoload.php';
 
-try {
+$kernel = new DrupalKernel('prod', $autoloader);
 
-  $request = Request::createFromGlobals();
-  $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod');
-  $response = $kernel
-      ->handle($request)
-      // Handle the response object.
-      ->prepare($request)->send();
-  $kernel->terminate($request, $response);
-}
-catch (HttpExceptionInterface $e) {
-  $response = new Response($e->getMessage(), $e->getStatusCode());
-  $response->prepare($request)->send();
-}
-catch (Exception $e) {
-  $message = 'If you have just changed code (for example deployed a new module or moved an existing one) read <a href="http://drupal.org/documentation/rebuild">http://drupal.org/documentation/rebuild</a>';
-  if (Settings::get('rebuild_access', FALSE)) {
-    $rebuild_path = $GLOBALS['base_url'] . '/rebuild.php';
-    $message .= " or run the <a href=\"$rebuild_path\">rebuild script</a>";
-  }
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
 
-  // Set the response code manually. Otherwise, this response will default to a
-  // 200.
-  http_response_code(500);
-  print $message;
-  throw $e;
-}
+$kernel->terminate($request, $response);

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -12,12 +12,8 @@
 #
 # For more information about the robots.txt standard, see:
 # http://www.robotstxt.org/robotstxt.html
-#
-# For syntax checking, see:
-# http://www.frobee.com/robots-txt-check
 
 User-agent: *
-Crawl-delay: 10
 # JS/CSS
 Allow: /core/*.css$
 Allow: /core/*.js$

--- a/web/sites/default/default.services.yml
+++ b/web/sites/default/default.services.yml
@@ -25,9 +25,9 @@ parameters:
     cookie_lifetime: 2000000
     #
     # Drupal automatically generates a unique session cookie name based on the
-    # full domain name used to access the site. This mechanism is sufficent for
-    # most use-cases, including multi-site deployments. However, if it is
-    # desired that a session can be reused accross different subdomains, the
+    # full domain name used to access the site. This mechanism is sufficient
+    # for most use-cases, including multi-site deployments. However, if it is
+    # desired that a session can be reused across different subdomains, the
     # cookie domain needs to be set to the shared base domain. Doing so assures
     # that users remain logged in as they cross between various subdomains.
     # To maximize compatibility and normalize the behavior across user agents,
@@ -51,7 +51,7 @@ parameters:
     #   changes (see auto_reload below).
     #
     # For more information about debugging Twig templates, see
-    # http://drupal.org/node/1906392.
+    # https://www.drupal.org/node/1906392.
     #
     # Not recommended in production environments
     # @default false
@@ -76,6 +76,14 @@ parameters:
     # Not recommended in production environments
     # @default true
     cache: true
+  renderer.config:
+    # Renderer required cache contexts:
+    #
+    # The Renderer will automatically associate these cache contexts with every
+    # render array, hence varying every render array by these cache contexts.
+    #
+    # @default ['languages:language_interface', 'theme']
+    required_cache_contexts: ['languages:language_interface', 'theme']
   factory.keyvalue:
     {}
     # Default key/value storage service to use.

--- a/web/sites/example.settings.local.php
+++ b/web/sites/example.settings.local.php
@@ -28,7 +28,7 @@ $config['system.performance']['css']['preprocess'] = FALSE;
 $config['system.performance']['js']['preprocess'] = FALSE;
 
 /**
- * Disable the render cache.
+ * Disable the render cache (this includes the page cache).
  *
  * This setting disables the render cache by using the Null cache back-end
  * defined by the development.services.yml file above.

--- a/web/sites/example.sites.php
+++ b/web/sites/example.sites.php
@@ -21,17 +21,17 @@
  *
  * Aliases are defined in an associative array named $sites. The array is
  * written in the format: '<port>.<domain>.<path>' => 'directory'. As an
- * example, to map http://www.drupal.org:8080/mysite/test to the configuration
+ * example, to map https://www.drupal.org:8080/mysite/test to the configuration
  * directory sites/example.com, the array should be defined as:
  * @code
  * $sites = array(
  *   '8080.www.drupal.org.mysite.test' => 'example.com',
  * );
  * @endcode
- * The URL, http://www.drupal.org:8080/mysite/test/, could be a symbolic link or
- * an Apache Alias directive that points to the Drupal root containing
+ * The URL, https://www.drupal.org:8080/mysite/test/, could be a symbolic link
+ * or an Apache Alias directive that points to the Drupal root containing
  * index.php. An alias could also be created for a subdomain. See the
- * @link http://drupal.org/documentation/install online Drupal installation guide @endlink
+ * @link https://www.drupal.org/documentation/install online Drupal installation guide @endlink
  * for more information on setting up domains, subdomains, and subdirectories.
  *
  * The following examples look for a site configuration in sites/example.com:
@@ -45,11 +45,11 @@
  * URL: http://localhost:8080/example
  * $sites['8080.localhost.example'] = 'example.com';
  *
- * URL: http://www.drupal.org:8080/mysite/test/
+ * URL: https://www.drupal.org:8080/mysite/test/
  * $sites['8080.www.drupal.org.mysite.test'] = 'example.com';
  * @endcode
  *
  * @see default.settings.php
  * @see conf_path()
- * @see http://drupal.org/documentation/install/multi-site
+ * @see https://www.drupal.org/documentation/install/multi-site
  */

--- a/web/web.config
+++ b/web/web.config
@@ -35,7 +35,7 @@
         </rule>
 
     <!-- To redirect all users to access the site WITH the 'www.' prefix,
-     http://example.com/... will be redirected to http://www.example.com/...)
+     http://example.com/foo will be redirected to http://www.example.com/foo)
      adapt and uncomment the following:   -->
     <!--
         <rule name="Redirect to add www" stopProcessing="true">
@@ -48,7 +48,7 @@
     -->
 
     <!-- To redirect all users to access the site WITHOUT the 'www.' prefix,
-     http://www.example.com/... will be redirected to http://example.com/...)
+     http://www.example.com/foo will be redirected to http://example.com/foo)
      adapt and uncomment the following:   -->
     <!--
         <rule name="Redirect to remove www" stopProcessing="true">


### PR DESCRIPTION
"A script to update `web` /
and the actual update of `web` /
by running the script."

---

The script is based on drush for several reasons:
- composer seems actually unable to download beta12. I've tried with:

```
composer require drupal/drupal:@beta
composer require drupal/drupal:8.0.0-beta12
```

It complains with `drupal/drupal 8.0.0-beta12 requires drupal/core ~8.0 -> no matching package found.` Perhaps I'm missing something obvious here.
- `drush dl` downloads a tgz, quite quicker than using composer to download `drupal/drupal` package and its dependencies
- `drush dl` downloads automatically the last version, no matter its stability (`@beta`, ...)
