### PR TITLE
Install the devel module as an optional development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,10 @@
         "drupal/core": "8.0.*",
         "drush/drush": "8.*",
 
-        "drupal/devel": "8.1.*@dev",
         "drupal/token": "8.1.*@dev"
+    },
+    "require-dev": {
+        "drupal/devel": "8.1.*@dev"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
The Devel module is only needed when developing, it is not needed in production.

If we put it in `require-dev` instead of in `require` we can do a production build with `composer install --no-dev` that will exclude the Devel module. This also demonstrates this best practice.
