### PR TITLE
Use pwd instead of realpath

### DIFF
--- a/scripts/drupal/update-scaffold
+++ b/scripts/drupal/update-scaffold
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT=`realpath "${CWD}/../.."`
+ROOT=$(pwd)
 
 drush dl drupal-8 --destination=/tmp --drupal-project-rename=drupal-8 --quiet -y
 
@@ -17,4 +16,3 @@ rsync -avz --delete /tmp/drupal-8/ $ROOT/web \
  --exclude=vendor
 
 rm -rf /tmp/drupal-8
-


### PR DESCRIPTION
`realpath` is not available OS X. I would like to have a update script that works on OS X.

The attached core works if we execute the script via `./scripts/drupal/update-scaffold`.

// @jonhattan What do you think?
