### PR TITLE
Use dev-master version of drush

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,8 @@
     "require": {
         "composer/installers": "^1.0.20",
         "drupal/core": "8.0.*",
-        "drush/drush": "8.*",
+        "drush/drush": "dev-master",
         "drupal/console": "~0.8",
-
         "drupal/devel": "8.1.*@dev",
         "drupal/token": "8.1.*@dev"
     },


### PR DESCRIPTION
Now that https://github.com/drush-ops/drush/pull/1595 has landed, and per the comments in #52, the new "finder" stage for Drush is helpful/necessary to use the copy in the vendor directory. In my case, this works without any other changes or magic; I have a global /etc/drush/drushrc.php file that specifies the path to Drush, but this works inside the web/ directory, as well.

Also removed an unnecessary blank line.
