### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "drupal-composer/drupal-project",
     "description": "Project template for Drupal 8 projects with composer",
-    "type": "project",
+    "type": "drupal-project",
     "license": "GPL-2.0+",
     "authors": [
         {


### PR DESCRIPTION
This would be a welcome change if or once https://github.com/composer/installers/pull/264 is accepted, for using drupal-composer/drupal-project itself as a dependency.
