### PR TITLE
Updates to update-scaffold script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ Updating Drupal core is a two-step process.
 
 1. Update the version number of `drupal/core` in `composer.json`.
 1. Run `composer update drupal/core`.
-1. Run `./scripts/drupal/update-scaffold` to update files in the `web` directory.
-   This will update `web` with whatever the latest Drupal 8 release is. Review
-   the files for any changes and restore any customizations to `.htaccess` or
-   `robots.txt`.
+1. Run `./scripts/drupal/update-scaffold [drush-version-spec]` to update files
+   in the `web` directory, where `drush-version-spec` is an optional identifier
+   acceptable to Drush, e.g. `drupal-8.0.x` or `drupal-8.1.x`, corresponding to
+   the version you specified in `composer.json`. (Defaults to `drupal-8`, the
+   latest stable release.) Review the files for any changes and restore any
+   customizations to `.htaccess` or `robots.txt`.
 1. Commit everything all together in a single commit, so `web` will remain in
    sync with the `core` when checking out branches or running `git bisect`.
 

--- a/scripts/drupal/update-scaffold
+++ b/scripts/drupal/update-scaffold
@@ -1,18 +1,23 @@
 #!/bin/bash
 
 ROOT=$(pwd)
+VERSION=${1:-drupal-8}
 
-drush dl drupal-8 --destination=/tmp --drupal-project-rename=drupal-8 --quiet -y
+drush dl "$VERSION" --destination=/tmp --drupal-project-rename=drupal-8 --quiet -y
 
 rsync -avz --delete /tmp/drupal-8/ $ROOT/web \
  --exclude=.gitkeep \
  --exclude=autoload.php \
  --exclude=composer.json \
+ --exclude=composer.lock \
  --exclude=core \
  --exclude=drush \
  --exclude=example.gitignore \
  --exclude=LICENSE.txt \
  --exclude=README.txt \
- --exclude=vendor
+ --exclude=vendor \
+ --exclude=sites \
+ --exclude=themes \
+ --exclude=modules
 
 rm -rf /tmp/drupal-8


### PR DESCRIPTION
1. ...so you can choose a more arbitrary core version descriptor, e.g., for -dev. Includes README update.
2. Updates exclusion for sites, themes, modules so you don't end up clobbering data you may have there. Core doesn't really provide anything in those directories, anyway, so no need to expect upstream changes.
