### PR TITLE
Add a helper to put vendor/bin in $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ cd some-dir
 composer require drupal/devel:8.*
 ```
 
+If you are adding command line tools like Drush through composer, you can add
+them to your shell's path by running `shell.sh` in the project's root
+directory.
+
 ## What does the template do?
 
 When installing the given `composer.json` some tasks are taken care of:

--- a/shell.sh
+++ b/shell.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Starting a new shell at $SHELL with $(pwd)/vendor/bin added to it's path."
+echo "Exit the shell to remove the path directory."
+PATH=$(pwd)/vendor/bin:$PATH $SHELL


### PR DESCRIPTION
With composer, it's really nice to be able to lock down CLI tools like Drush on a per-project basis. However, keeping ~/.zshrc up to date with a PATH variable is a pain. This helper avoids all of that by creating a subshell with the right path that can easily be reset with an exit.
