### PR TITLE
Explicitly run post-install as a shell script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "post-install-cmd": "scripts/composer/post-install.sh"
+        "post-install-cmd": "sh ./scripts/composer/post-install.sh"
     },
     "extra": {
         "installer-paths": {


### PR DESCRIPTION
This fixes an issue that occurs when running the post-install script on Windows.
When you try to run the post-install script on Windows you receive this error:
'scripts' is not recognized as an internal or external command,
operable program or batch file.

Assuming you have the UNIX tools included with https://git-for-windows.github.io
installed, the post-install script will now run as expected.

Fixes #65
