### PR TITLE
Exclude modules and themes which depend on Drupal 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "derhasi/composer-preserve-paths": "0.1.*",
     "drupal/drupal": "7.*"
   },
+  "conflict": {
+    "drupal/core": "8.*"
+  },
   "scripts": {
     "post-create-project-cmd": [
       "rm README.md LICENSE .travis.yml phpunit.xml.dist"


### PR DESCRIPTION
This should exclude any project which depend on Drupal 8. I tested the behaviour with inline_entity_form. `composer require drupal/inline_entity_form:@dev`
