### PR TITLE
Use composer-patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,14 @@ Composer recommends **no**. They provide [argumentation against but also workrou
 ### How can I apply patches to downloaded modules?
 
 If you need to apply patches (depending on the project being modified, a pull request is often a better solution), you can do so with the [composer-patches](https://github.com/cweagans/composer-patches) plugin.
+
+To add a patch to drupal module foobar insert the patches section in the extra section of composer.json:
+```json
+"extra": {
+    "patches": {
+        "drupal/foobar": {
+            "Patch description": "URL to patch"
+        }
+    }
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "composer/installers": "^1.0.20",
+        "cweagans/composer-patches": "~1.0",
         "drupal/core": "8.0.*",
         "drush/drush": "dev-master",
         "drupal/console": "dev-master"


### PR DESCRIPTION
Following the documentation work done in #73, I'm proposing to add cweagans/composer-patches to the required packages in composer.json, and to document how to use it in the README.md.

I'm pretty sure this package will be used by everyone as long as we have the current patch workflow in drupal.org.
