### PR TITLE
Use stable versions of Drush and Drupal Console.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "composer/installers": "^1.0.20",
         "cweagans/composer-patches": "~1.0",
         "drupal/core": "8.0.*",
-        "drush/drush": "dev-master",
-        "drupal/console": "dev-master"
+        "drush/drush": "~8",
+        "drupal/console": "~8"
     },
     "require-dev": {
         "behat/mink": "~1.6",


### PR DESCRIPTION
Both Drush and Drupal Composer now have stable releases on their 8.x branches.  We should prefer these over the dev releases.
