### PR TITLE
Add drupal-security-advisories and roave/security-advisories.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "composer/installers": "^1.0.20",
         "cweagans/composer-patches": "~1.0",
-        "webflo/drupal-security-advisories": "8.0.x-dev",
+        "drupal-composer/drupal-security-advisories": "8.0.x-dev",
         "roave/security-advisories": "dev-master",
         "drupal/core": "8.0.*",
         "drush/drush": "~8.0",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
     "require": {
         "composer/installers": "^1.0.20",
         "cweagans/composer-patches": "~1.0",
+        "webflo/drupal-security-advisories": "8.0.x-dev",
+        "roave/security-advisories": "dev-master",
         "drupal/core": "8.0.*",
         "drush/drush": "~8.0",
         "drupal/console": "~0.9"


### PR DESCRIPTION
webflo/drupal-security-advisories and roave/security-advisories are super cool, and very helpful should folks get into the habit of pinning their requirements to very specific versions.  Seems like it would be a good idea to encourage folks to use them by default.

Maybe we should move webflo/drupal-security-advisories  to drupal-composer/drupal-security-advisories first?
