### PR TITLE
Add web/drush.wrapper scaffold file for restricting commands/aliases/config to local repo.

### DIFF
--- a/web/drush.wrapper
+++ b/web/drush.wrapper
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+#
+# DRUSH WRAPPER
+#
+# A wrapper script which launches the Drush that is in your project's /vendor
+# directory.  Copy it to the root of your project and edit as desired.
+# You may rename this script to 'drush', if doing so does not cause a conflict
+# (e.g. with a folder __ROOT__/drush).
+#
+# Below are options which you might want to add. More info at
+# `drush topic core-global-options`:
+#
+# --local       Only discover commandfiles/site aliases/config that are
+#               inside your project dir.
+# --alias-path  A list of directories where Drush will search for site
+#               alias files.
+# --config      A list of paths to config files
+# --include     A list of directories to search for commandfiles.
+#
+# Note that it is recommended to use --local when using a drush
+# wrapper script.
+#
+# See the 'drush' script in the Drush installation root (../drush) for
+# an explanation of the different 'drush' scripts.
+#
+# IMPORTANT:  Modify the path below if your 'vendor' directory has been
+# relocated to another location in your composer.json file.
+# `../vendor/bin/drush.launcher --local $@` is a common variant for
+# composer-managed Drupal sites.
+#
+cd "`dirname $0`"
+../vendor/bin/drush.launcher --local "$@"

--- a/web/drush.wrapper
+++ b/web/drush.wrapper
@@ -29,4 +29,4 @@
 # composer-managed Drupal sites.
 #
 cd "`dirname $0`"
-../vendor/bin/drush.launcher --local "$@"
+../vendor/bin/drush.launcher "$@"


### PR DESCRIPTION
Drush has support for a drush.wrapper in Drupal root which customizes how Drush gets called. The wrapper I propose here adds --local to all Drush requests. This tells Drush not to scan for config, site aliases, and commandfiles in global locations (e.g. ~/.drush, /etc/drush, ...). This environment isolation is very helpful - all Drush requests run the same no matter who's system you are on. Furthermore, it emphasizes that Drush files go in this repo's /drush dir, not in legacy places like ~/.drush. In the rare cases when globally installed commands are needed and can't be copied to our /drush for some reason, user can add --no-local to her request (or in the extreme permanently remove --local from this file).

In order to test this PR, make sure you have some commandfiles, config, or aliases installed to ~/.drush. Then run a `drush sa --root=/path/to/web`. Notice how your global commands/aliases/config are no longer in effect with this PR.
