### PR TITLE
Ignore drupal/drupal and all Drupal 6 and 7 Modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "phpunit/phpunit": "~4.8",
         "symfony/css-selector": "2.7.*"
     },
+    "conflict": {
+        "drupal/drupal": "*"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {


### PR DESCRIPTION
Similar to #71, but we exclude D6 and D7 modules this time.
