### PR TITLE
Workaround for permission denied when executed from Git Bash

### DIFF
--- a/scripts/composer/post-install.sh
+++ b/scripts/composer/post-install.sh
@@ -17,5 +17,6 @@ fi
 # Prepare the files directory for installation
 if [ ! -d web/sites/default/files ]
   then
-    mkdir -m777 web/sites/default/files
+    mkdir web/sites/default/files
+    chmod 777 web/sites/default/files
 fi


### PR DESCRIPTION
When executed from a Git Bash environment the command `mkdir -m777` fails with a `Permission denied` error. Executing the mkdir followed by chmod solves the problem.

![permission denied](https://cloud.githubusercontent.com/assets/17079617/12843231/442a437a-cbf8-11e5-8ba7-f7a6e67ad53d.png)
