### PR TITLE
install destination for third-party libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
+            "web/sites/all/libraries/{$name}": ["type:drupal-library"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
         }
     }


### PR DESCRIPTION
Third-party libraries (e.g. juicebox.js which drupal/juicebox needs) currently, and somewhat to my surprise in Drupal 8, have to be installed in `web/sites/all/libraries`
