### PR TITLE
Create a hash_salt value for settings.php in post-install.sh

### DIFF
--- a/scripts/composer/post-install.sh
+++ b/scripts/composer/post-install.sh
@@ -14,7 +14,10 @@ fi
 # Prepare the settings file for installation
 if [ ! -f $DOCUMENTROOT/sites/default/settings.php ]
   then
-    cp $DOCUMENTROOT/sites/default/default.settings.php $DOCUMENTROOT/sites/default/settings.php
+    sed \
+      -e "s/\(\$settings\['hash_salt'\] = \)'';/\1'$(php -r 'print bin2hex(openssl_random_pseudo_bytes(32));')';/" \
+      $DOCUMENTROOT/sites/default/default.settings.php \
+      > $DOCUMENTROOT/sites/default/settings.php
     chmod 666 $DOCUMENTROOT/sites/default/settings.php
     echo "Create a sites/default/settings.php file with chmod 666"
 fi


### PR DESCRIPTION
In case user wishes to copy an existing database rather than install a new site.

I put this in with `sed` so that the hash salt value would be placed in settings.php in the same place it would if the Drupal installer were run.  Perhaps the extra complexity is not worth the benefit, though; not sure how I feel about this.
