### PR TITLE
Improve directory scaffolding; add .gitkeep files

### DIFF
--- a/scripts/composer/post-install.sh
+++ b/scripts/composer/post-install.sh
@@ -6,9 +6,11 @@ DOCUMENTROOT=web
 if [ ! -f $DOCUMENTROOT/autoload.php ]
   then
     composer drupal-scaffold
-    mkdir -p $DOCUMENTROOT/modules
-    mkdir -p $DOCUMENTROOT/themes
-    mkdir -p $DOCUMENTROOT/profiles
+    for dir in modules themes profiles
+    do
+      mkdir -p $DOCUMENTROOT/$dir
+      touch $DOCUMENTROOT/$dir/.gitkeep
+    done
 fi
 
 # Prepare the settings file for installation


### PR DESCRIPTION
Use a foreach loop, and also add a .gitkeep file to the directories.

**Motivation** - I tried to run tests using `run-tests.sh` and got some vague failures since Drupal's test script isn't particularly verbose. Tracked this down to `core/tests/bootstrap.php` which was trying to recursively search the `profiles` directory, which did not exist. That's because I had originally created this project on another machine, committed it to git, and then fired it back up on my current node. However, the empty directories created in `post-install.sh` did not get committed, per git's usual behavior.

The directories aren't re-created on `composer install` because `web/autoload.php` already existed. Empty directory, can't scan, makes PHPUnit unhappy.
