### PR TITLE
Fixed settings.php, services.yml and files directory creation process

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -44,21 +44,23 @@ class ScriptHandler {
     // Prepare the settings file for installation
     if (!$fs->exists($root . '/sites/default/settings.php')) {
       $fs->copy($root . '/sites/default/default.settings.php', $root . '/sites/default/settings.php');
-      $fs->chmod($root . '/sites/default/settings.php', 666);
+      $fs->chmod($root . '/sites/default/settings.php', 0666);
       $event->getIO()->write("Create a sites/default/settings.php file with chmod 666");
     }
 
     // Prepare the services file for installation
     if (!$fs->exists($root . '/sites/default/services.yml')) {
       $fs->copy($root . '/sites/default/default.services.yml', $root . '/sites/default/services.yml');
-      $fs->chmod($root . '/sites/default/services.yml', 666);
+      $fs->chmod($root . '/sites/default/services.yml', 0666);
       $event->getIO()->write("Create a sites/default/services.yml file with chmod 666");
     }
 
     // Prepare the files directory for installation
     if (!$fs->exists($root . '/sites/default/files')) {
-      $fs->chmod($root . '/sites/default/services.yml', 777);
-      $event->getIO()->write("Create a sites/default/files directory with chmod 777");
+      $oldmask = umask(0); // Temporarily set the umask to 0 to get correct permissions
+      $fs->mkdir($root . '/sites/default/files', 0777);
+      umask($oldmask); // Revert umask to original value
+      $event->getIO()->write("Create a sites/default/files directory with chmod 0777");
     }
   }
 

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -55,7 +55,7 @@ class ScriptHandler {
       $event->getIO()->write("Create a sites/default/services.yml file with chmod 666");
     }
 
-    // Prepare the files directory for installation
+    // Create the files directory with chmod 0777
     if (!$fs->exists($root . '/sites/default/files')) {
       $oldmask = umask(0);
       $fs->mkdir($root . '/sites/default/files', 0777);

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -57,9 +57,9 @@ class ScriptHandler {
 
     // Prepare the files directory for installation
     if (!$fs->exists($root . '/sites/default/files')) {
-      $oldmask = umask(0); // Temporarily set the umask to 0 to get correct permissions
+      $oldmask = umask(0);
       $fs->mkdir($root . '/sites/default/files', 0777);
-      umask($oldmask); // Revert umask to original value
+      umask($oldmask);
       $event->getIO()->write("Create a sites/default/files directory with chmod 0777");
     }
   }


### PR DESCRIPTION
The settings.php and services.yml files were getting created empty with the permissions "--w--wx-wT". They need to use the octal "0666" to work correctly.

The files directory wasn't being created at all (a copy and paste error was trying to create another services.yml file.) Also, the directory was being created with incorrect permissions due to umask. I've added two lines to temporarily set umask to "0" and then restore the original value after the files directory is created.
