### PR TITLE
Support Drupal 8.1 and newer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/installers": "^1.0.20",
         "drupal-composer/drupal-scaffold": "^1.3.1",
         "cweagans/composer-patches": "~1.0",
-        "drupal/core": "8.0.*",
+        "drupal/core": "~8.0",
         "drush/drush": "~8.0",
         "drupal/console": "~0.10"
     },


### PR DESCRIPTION
This allows sites to install any compatible Drupal 8 release instead of just 8.0.x.
