### PR TITLE
Adds a name key to repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
             "role": ""
         }
     ],
-    "repositories": [
+    "repositories": {
         "drupal": {
             "type": "composer",
-            "url": "https://packagist.drupal-composer.org"
+            "url": "https://packages.drupal.org/8"
         }
-    ],
+    },
     "require": {
         "composer/installers": "^1.0.20",
         "drupal-composer/drupal-scaffold": "^2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "repositories": [
-        {
+        "drupal": {
             "type": "composer",
             "url": "https://packagist.drupal-composer.org"
         }


### PR DESCRIPTION
Having a key name in the repositories will make it marginally easier to change the repo from the command line:

`composer config repositories.drupal composer https://packages.drupal.org/8`

is easier than telling folks to edit json.
