### PR TITLE
Check the Composer version before downloading the dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,12 @@
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "pre-install-cmd": [
+            "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
+        ],
+        "pre-update-cmd": [
+            "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
+        ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -84,7 +84,7 @@ class ScriptHandler {
       $io->writeError('<warning>You are running a development version of Composer. If you experience problems, please update Composer to the latest stable version.</warning>');
     }
     elseif (Comparator::lessThan($version, '1.0.0')) {
-      $io->writeError('<error>Drupal-project requires Composer version 1.0.0 or higher. Please update your Composer before continuing.');
+      $io->writeError('<error>Drupal-project requires Composer version 1.0.0 or higher. Please update your Composer before continuing</error>.');
       exit(1);
     }
   }

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -58,6 +58,20 @@ class ScriptHandler {
     }
   }
 
+  /**
+   * Checks if the installed version of Composer is compatible.
+   *
+   * Composer 1.0.0 and higher consider a `composer install` without having a
+   * lock file present as equal to `composer update`. We do not ship with a lock
+   * file to avoid merge conflicts downstream, meaning that if a project is
+   * installed with an older version of Composer the scaffolding of Drupal will
+   * not be triggered. We check this here instead of in drupal-scaffold to be
+   * able to give immediate feedback to the end user, rather than failing the
+   * installation after going through the lengthy process of compiling and
+   * downloading the Composer dependencies.
+   *
+   * @see https://github.com/composer/composer/pull/5035
+   */
   public static function checkComposerVersion(Event $event) {
     $composer = $event->getComposer();
     $io = $event->getIO();

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -8,6 +8,7 @@
 namespace DrupalProject\composer;
 
 use Composer\Script\Event;
+use Composer\Semver\Comparator;
 use Symfony\Component\Filesystem\Filesystem;
 
 class ScriptHandler {
@@ -54,6 +55,23 @@ class ScriptHandler {
       $fs->mkdir($root . '/sites/default/files', 0777);
       umask($oldmask);
       $event->getIO()->write("Create a sites/default/files directory with chmod 0777");
+    }
+  }
+
+  public static function checkComposerVersion(Event $event) {
+    $composer = $event->getComposer();
+    $io = $event->getIO();
+
+    $version = $composer::VERSION;
+
+    // If Composer is installed through git we have no easy way to determine if
+    // it is new enough, just display a warning.
+    if ($version === '@package_version@') {
+      $io->writeError('<warning>You are running a development version of Composer. If you experience problems, please update Composer to the latest stable version.</warning>');
+    }
+    elseif (Comparator::lessThan($version, '1.0.0')) {
+      $io->writeError('<error>Drupal-project requires Composer version 1.0.0 or higher. Please update your Composer before continuing.');
+      exit(1);
     }
   }
 


### PR DESCRIPTION
I experienced a problem yesterday during a workshop where people weren't able to scaffold Drupal correctly. This turned out to be caused by doing an initial installation using an outdated version of composer.

We do not have the `composer.lock` file committed (to avoid merge conflicts downstream) and an initial installation without a lock file is now considered to be an update command. This change has been recently introduced in Composer (in https://github.com/composer/composer/pull/5035). If someone is using an older version this means the Drupal scaffolding is not performed.

Since this change has been introduced shortly before Composer 1.0.0 I would propose to check for this version.
