### PR TITLE
Update composer.json to use drupal.org packagist.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://packagist.drupal-composer.org"
+            "url": "https://packages.drupal.org/8"
         }
     ],
     "require": {


### PR DESCRIPTION
We might want to start using https://packages.drupal.org/8.
