### PR TITLE
WIP feat(docroot): Use a dedicated docroot with no core files in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,36 @@ all files not excluded by the .gitignore file.
 
 When installing the given `composer.json` some tasks are taken care of:
 
-* Drupal will be installed in the `web`-directory.
-* Autoloader is implemented to use the generated composer autoloader in `vendor/autoload.php`,
-  instead of the one provided by Drupal (`web/vendor/autoload.php`).
-* Modules (packages of type `drupal-module`) will be placed in `web/modules/contrib/`
-* Theme (packages of type `drupal-theme`) will be placed in `web/themes/contrib/`
-* Profiles (packages of type `drupal-profile`) will be placed in `web/profiles/contrib/`
+* Drupal will be installed in the project root directory.
+* A dedicated document root "web" directory will be created. This is where your
+* web server configuration should point to. See the web server section below.
+* Modules (packages of type `drupal-module`) will be placed in `modules/contrib/`
+* Theme (packages of type `drupal-theme`) will be placed in `themes/contrib/`
+* Profiles (packages of type `drupal-profile`) will be placed in `profiles/contrib/`
 * Creates default writable versions of `settings.php` and `services.yml`.
-* Creates `sites/default/files`-directory.
+* Creates `web/files`-directory.
 * Latest version of drush is installed locally for use at `vendor/bin/drush`.
 * Latest version of DrupalConsole is installed locally for use at `vendor/bin/drupal`.
+
+
+## Web server configuration
+
+Because we use a dedicated web docroot for security reasons we need to have an
+additional web server config entry to map static assets files from core, modules
+and themes.
+
+Nginx:
+
+```
+location ~* ^/(core|modules|themes)/.+\.(js|css|png|jpg|jpeg|gif|ico|svg|ttf|eot|woff|otf)$ {
+  # @todo we need to change to docroot to one folder up here. With 'root'? Or
+  # with 'alias'? Can we make it work relatively by reusing to old docroot?
+  expires       max;
+  log_not_found off;
+  try_files     /web$uri $uri =404;
+}
+
+```
 
 ## Updating Drupal Core
 

--- a/composer.json
+++ b/composer.json
@@ -59,11 +59,11 @@
     },
     "extra": {
         "installer-paths": {
-            "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
-            "web/modules/contrib/{$name}": ["type:drupal-module"],
-            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "web/themes/contrib/{$name}": ["type:drupal-theme"],
+            "core": ["type:drupal-core"],
+            "libraries/{$name}": ["type:drupal-library"],
+            "modules/contrib/{$name}": ["type:drupal-module"],
+            "profiles/contrib/{$name}": ["type:drupal-profile"],
+            "themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
         }
     }


### PR DESCRIPTION
Trying to use this project with an empty docroot for security reasons, see https://www.drupal.org/node/2767907

This is not complete yet. 2 problems:
1) we need additional web server config directives to map static assets (js, css, images). We want to avoid the rsync hack or copying around files, a web server is perfectly capable of mapping the files for us.
2) The generated settings.php file needs `$settings['file_public_base_url']` which contains a domain that we just set to localhost for now.
