### PR TITLE
Change drupal-scaffold command name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         ]
     },
     "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "drupal:scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "pre-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],


### PR DESCRIPTION
New command name could be `drupal:scaffold`, as Composer separates these commands in different sections. Think of it as a command namespace.

Example:
![Imgur](http://i.imgur.com/uZQx2Zd.png)

Of course these would comply to [drupal-scaffold](https://github.com/drupal-composer/drupal-scaffold) too.
