### PR TITLE
Set Enable Patching to true

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
-        }
+        },
+        "enable-patching": true
     }
 }


### PR DESCRIPTION
This PR probably does want some thought beyond bug fix... lets merge. This adds 'enable-patching' = true to the extras key. This means that patches from projects will be applied. This is obviously great in many ways but it is a significant change. 
Example of usage: https://drupal.org/project/field_states_ui is applying a patch to core so as to be able to use a hook that doesn't exist, without killing kittens.
