### PR TITLE
Add documentation on how to install libraries using composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,40 @@ section of composer.json:
     }
 }
 ```
+
+### How can I add libraries using composer.json?
+
+It is possible to use libraries with composer with an extra repository for each
+library you want to use. For example, to use colorbox:
+```json
+"repositories": [
+    ...,
+    {
+        "type": "package",
+        "package": {
+            "name": "jackmoore/colorbox",
+            "type": "drupal-library",
+            "version": "1.6.4",
+            "dist": {
+                "url": "https://github.com/jackmoore/colorbox/archive/1.6.4.zip",
+                "type": "zip"
+            },
+            "source": {
+                "url": "https://github.com/jackmoore/colorbox.git",
+                "type": "git",
+                "reference": "tags/1.6.4"
+            }
+        }
+    }
+],
+```
+
+The version has to be manually updated with a new release as composer can't
+detect a new version from the above package.
+
+When managing libraries with composer this way, you may not want to add it to
+version control. In that case, add specific directories to the .gitignore file.
+```
+# Specific libraries (which we manage with composer)
+docroot/libraries/colorbox
+```

--- a/README.md
+++ b/README.md
@@ -142,3 +142,12 @@ version control. In that case, add specific directories to the .gitignore file.
 # Specific libraries (which we manage with composer)
 docroot/libraries/colorbox
 ```
+
+*Note*: This has a few limitations and should be avoided when possible.
+
+* Composer will not update the package unless you change the `version` field.
+* Composer will not update the commit references, so if you use master as
+  reference you will have to delete the package to force an update, and will
+  have to deal with an unstable lock file.
+
+For more details, see https://getcomposer.org/doc/05-repositories.md#package-2


### PR DESCRIPTION
The composer.json in the project allows placing components marked as drupal-library in the
correct directory, but most libraries are not available to composer by default. We should
add documentation on how to add a repository with an example to help get users started.