### PR TITLE
Minor README improvement: embed only valid json

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ achieve that by registering `@drupal-scaffold` as post-install and post-update c
 "scripts": {
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "post-install-cmd": [
-        "@drupal-scaffold"
+        "@drupal-scaffold",
+        "..."
     ],
     "post-update-cmd": [
-        "@drupal-scaffold"
+        "@drupal-scaffold",
+        "..."
     ]
 },
 ```

--- a/README.md
+++ b/README.md
@@ -100,12 +100,10 @@ achieve that by registering `@drupal-scaffold` as post-install and post-update c
 "scripts": {
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "post-install-cmd": [
-        "@drupal-scaffold",
-        ...
+        "@drupal-scaffold"
     ],
     "post-update-cmd": [
-        "@drupal-scaffold",
-        ...        
+        "@drupal-scaffold"
     ]
 },
 ```


### PR DESCRIPTION
Invalid json is displayed on a distracting bright red background. This commit removes the ellipsis from the example json - people will have to understand they have to merge the existing commands in the object.