### PR TITLE
Ignore web/libraries directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /web/modules/contrib/
 /web/themes/contrib/
 /web/profiles/contrib/
+/web/libraries/
 
 # Ignore Drupal's file directory
 /web/sites/*/files/


### PR DESCRIPTION
The `composer.json` in the project allows placing components marked as `drupal-library` in the
correct directory, ignore this directory. Related to #215