### PR TITLE
also ignore /web/libraries/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /web/modules/contrib/
 /web/themes/contrib/
 /web/profiles/contrib/
+/web/libraries/
 
 # Ignore Drupal's file directory
 /web/sites/*/files/


### PR DESCRIPTION
libraries are also managed by composer: https://github.com/drupal-composer/drupal-project/blob/8.x/composer.json#L63

therefore we can ignore them