### PR TITLE
gitgnore example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@
 /web/sites/*/settings.php
 /web/sites/*/settings.local.php
 
+# Ignore example files
+/web/sites/default/default.services.yml
+/web/sites/default/default.settings.php
+/web/sites/example.*.php
+
 # Ignore Drupal's file directory
 /web/sites/*/files/
 


### PR DESCRIPTION
Continuing a bit the work in #178, #210 and #245, I'm proposing that the Drupal core-generated example files like default.services.yml, default.settings.php, example.settings.local.php and example.sites.php be excluded from git.

These files are somewhat commonly changed by Drupal core, but I don't see anyone being interested in these changes being tracked in their project repos.

There are some other files added by installing Drupal, but these I concede might be useful to track, in some use cases.
web/.csslintrc
web/.editorconfig
web/.eslintignore
web/.eslintrc
web/.gitattributes
web/.htaccess
web/autoload.php
web/index.php
web/sites/default/services.yml
web/sites/development.services.yml
web/update.php
web/web.config