### PR TITLE
Add update db after updating modules.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "drush -y --root=web updatedb"
         ]
     },
     "extra": {


### PR DESCRIPTION
I feel is a very nice thing to add to the workflow to ensure that the database is consistent.
I'm thinking of cases when this may be to drastic but I can't come up with any.
I even add a drush config-export after the updb but I guess that really depends on the workflow.

Should I open an issue apart from the Pull request?