### PR TITLE
Use drupal-core-strict.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - composer --verbose install
 
 script:
-  - if [[ $RELEASE = dev ]]; then composer --verbose require --no-update drupal/core:8.4.x-dev; fi;
+  - if [[ $RELEASE = dev ]]; then composer --verbose require --no-update drupal/core:8.4.x-dev webflo/drupal-core-strict2:8.4.x-dev; fi;
   - if [[ $RELEASE = dev ]]; then composer --verbose update; fi;
   - cd $TRAVIS_BUILD_DIR/web
   - ./../vendor/bin/drush site-install --verbose --yes --db-url=sqlite://tmp/site.sqlite

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/console": "~1.0",
-        "drupal/core": "~8.0",
-        "drush/drush": "~8.0",
+        "drupal/core": "^8",
+        "drush/drush": "^8",
         "webflo/drupal-finder": "^0.2.1",
+        "webflo/drupal-core-strict": "^8",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
     ],
     "repositories": [
         {
+            "type": "vcs",
+            "url": "https://github.com/webflo/drupal-core-strict2.git",
+            "no-api" : true
+        },
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
@@ -20,10 +25,10 @@
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/console": "~1.0",
-        "drupal/core": "^8",
-        "drush/drush": "^8",
+        "drupal/core": "^8.3.0",
+        "drush/drush": "^8.1.10",
         "webflo/drupal-finder": "^0.2.1",
-        "webflo/drupal-core-strict": "^8",
+        "webflo/drupal-core-strict2": "^8.3.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
With the [current twig regression](https://www.drupal.org/node/2869528), Composer-managed Drupal sites will get a too-recent version of Twig, and experience problems.

Should we perhaps prevent this by using the `webflo/drupal-core-strict` project? Seems to work well and solve the problem.