### PR TITLE
default.services.yml should not be copied to services.yml

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -51,13 +51,6 @@ class ScriptHandler {
       $event->getIO()->write("Create a sites/default/settings.php file with chmod 0666");
     }
 
-    // Prepare the services file for installation
-    if (!$fs->exists($drupalRoot . '/sites/default/services.yml') and $fs->exists($drupalRoot . '/sites/default/default.services.yml')) {
-      $fs->copy($drupalRoot . '/sites/default/default.services.yml', $drupalRoot . '/sites/default/services.yml');
-      $fs->chmod($drupalRoot . '/sites/default/services.yml', 0666);
-      $event->getIO()->write("Create a sites/default/services.yml file with chmod 0666");
-    }
-
     // Create the files directory with chmod 0777
     if (!$fs->exists($drupalRoot . '/sites/default/files')) {
       $oldmask = umask(0);


### PR DESCRIPTION
I just deleted services.yml from my project as I am not overriding anything from core, source on that: https://www.drupal.org/node/2547447.

Running composer install afterwards re-created the services.yml and for reasons mentioned in that core issue this should not happen.