### PR TITLE
By yanniboi: Updated composer drush version to 9.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/console": "~1.0",
         "drupal/core": "~8.0",
-        "drush/drush": "~8.0",
+        "drush/drush": "~9.0",
         "webflo/drupal-finder": "^0.2.1",
         "webmozart/path-util": "^2.3"
     },


### PR DESCRIPTION
Trying to fix the composer dependency jumble with drupal 8 dev (8.4.x-dev) which seems to now be liking the drush version...