### PR TITLE
Adding a new create-project-symlinks command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "create-project-symlinks": "DrupalProject\\composer\\ScriptHandler::createProjectSymlinks",
         "pre-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],


### PR DESCRIPTION
When creating a drupal project, it is very common to create a site-specific set of modules, themes, and installation profiles.  

This patch adds a composer command `create-project-symlinks` that looks in the project's root directory for `module`, `theme`, and `profile` directories, and if it finds them, symlinks them into the correct place in the web directory. 