### PR TITLE
Add modules/custom and themes/custom

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,15 @@
       "web/profiles/{$name}/": ["type:drupal-profile"]
     },
     "preserve-paths": [
-      "web/sites/all/modules/contrib",
-      "web/sites/all/themes/contrib",
-      "web/sites/all/libraries",
       "web/sites/all/drush",
-      "web/sites/default/settings.php",
-      "web/sites/default/files"
+      "web/sites/all/libraries",
+      "web/sites/all/modules/contrib",
+      "web/sites/all/modules/custom",
+      "web/sites/all/modules/features",
+      "web/sites/all/themes/contrib",
+      "web/sites/all/themes/custom",
+      "web/sites/all/translations",
+      "web/sites/default"
     ]
   }
 }


### PR DESCRIPTION
See also https://www.drupal.org/node/2621480.

I'm proposing a patch that preserves the contents of sites/all/modules/custom and sites/all/themes/custom, which are otherwise wiped out when running composer. Likewise for sites/all/modules/features and sites/all/translations.

In addition, the patch simplifies the preserve path to include all of sites/default, as most of us leave other files there other than settings.php and files (the directory). In my case I usually have a drushrc.php and a settings.local.php in sites/default.. Instead of specifying each one, it's simpler to just preserve the whole path.

Finally, it reorders the preserve-paths alphabetically, to increase readability and simplify future maintenance.