### PR TITLE
Remove files that are specific to drupal-project after create project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+        ],
+        "post-create-project-cmd": [
+            "DrupalProject\\composer\\ScriptHandler::removeInternalFiles"
         ]
     },
     "extra": {

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -61,6 +61,27 @@ class ScriptHandler {
   }
 
   /**
+   * Remove project-internal files after create project.
+   */
+  public static function removeInternalFiles(Event $event) {
+    $fs = new Filesystem();
+
+    // List of files to be removed.
+    $files = [
+      '.travis.yml',
+      'LICENSE',
+      'README.md',
+      'phpunit.xml.dist',
+    ];
+
+    foreach ($files as $file) {
+      if ($fs->exists($file)) {
+        $fs->remove($file);
+      }
+    }
+  }
+
+  /**
    * Checks if the installed version of Composer is compatible.
    *
    * Composer 1.0.0 and higher consider a `composer install` without having a


### PR DESCRIPTION
This patch returns the post-create-project step that was added in PR #7 to the 8.x branch. There's no need to keep the LICENSE and README.txt files. The phpunit.xml.dist and .travis.yml are used only for the project testing and should also be removed.