### PR TITLE
Make "component" packages install to libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "drupal/console": "^1.0.1",
         "drupal/core": "~8.0",
         "drush/drush": "~8.0|^9.0.0-beta7",
+        "oomphinc/composer-installers-extender": "^1.1",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },
@@ -63,9 +64,13 @@
         ]
     },
     "extra": {
+        "installer-types": ["component"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
+            "web/libraries/{$name}": [
+                "type:drupal-library",
+                "type:component"
+            ],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],


### PR DESCRIPTION
From https://github.com/drupal-composer/drupal-project/pull/319 , allows installation of packages that are of type `component`.

Many of these live over at https://github.com/components .
