### PR TITLE
Support "component" libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/console": "^1.0.1",
         "drupal/core": "~8.0",
         "drush/drush": "~8.0|^9.0.0-beta7",
+        "oomphinc/composer-installers-extender": "^1.1",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },
@@ -63,9 +63,13 @@
         ]
     },
     "extra": {
+        "installer-types": ["component"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
+            "web/libraries/{$name}": [
+                "type:component",
+                "type:drupal-library"
+            ],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],


### PR DESCRIPTION
This allows libraries like [components/chosen](https://github.com/components/chosen), [components/jquery_ns_autogrow](https://github.com/components/jquery_ns_autogrow), [components/Sortable](https://github.com/components/Sortable) (for Paragraphs v1.2), and others required by certain Drupal modules to be included without extra effort by the developer.