### PR TITLE
Update deprecated license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "drupal-composer/drupal-project",
     "description": "Project template for Drupal 8 projects with composer",
     "type": "project",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "",


### PR DESCRIPTION
Running `composer validate` gives warning

> License "GPL-2.0+" is a deprecated SPDX license identifier, use "GPL-2.0+-only" or "GPL-2.0+-or-later" instead