### PR TITLE
Modify the default settings so that if patches cannot be applied the composer install step fails.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
-        }
+        },
+        "composer-exit-on-patch-failure": true
     }
 }


### PR DESCRIPTION
Hi! I propose this small change:

As found on the readme of the "composer-patches" package, the default behaviour is that a patch cannot be applied the build is allowed to continue.
In my opinion that is not a useful behaviour to have as the default because unpatched modules and core might end up in production, so I propose to set this setting to "TRUE" so that if patching fails the build is not allowed to go through.
People would still be able to remove that to get the old behaviour if desired.

More info on the readme of the composer-patches package at: https://github.com/cweagans/composer-patches#error-handling