### PR TITLE
Add platform version to FAQ to help user specifying PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,15 @@ section of composer.json:
 ### How do I switch from packagist.drupal-composer.org to packages.drupal.org?
 
 Follow the instructions in the [documentation on drupal.org](https://www.drupal.org/docs/develop/using-composer/using-packagesdrupalorg).
+
+### How do I specify a PHP version ?
+
+Currently Drupal 8 supports PHP 5.5.9 as minimum version (see [Drupal 8 PHP requirements](https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements)), however it's possible that a `composer update` will upgrade some package that will then require PHP 7+.
+
+To prevent this you can add this code to specify the PHP version you want to use in the `config` section of `composer.json`:
+```json
+"config": {
+    "sort-packages": true,
+    "platform": {"php": "5.5.9"}
+},
+```


### PR DESCRIPTION
I was thinking adding this directly to `composer.json` but it could be too restrictive to target PHP 5.5.9, so I added a FAQ section to `README.md`.

Fixes #359.