### PR TITLE
Updated argument name

### DIFF
--- a/drush/Commands/PolicyCommands.php
+++ b/drush/Commands/PolicyCommands.php
@@ -19,7 +19,7 @@ class PolicyCommands extends DrushCommands {
    * @throws \Exception
    */
   public function sqlSyncValidate(CommandData $commandData) {
-    if ($commandData->input()->getArgument('destination') == '@prod') {
+    if ($commandData->input()->getArgument('target') == '@prod') {
       throw new \Exception(dt('Per !file, you may never overwrite the production database.', ['!file' => __FILE__]));
     }
   }
@@ -32,7 +32,7 @@ class PolicyCommands extends DrushCommands {
    * @throws \Exception
    */
   public function rsyncValidate(CommandData $commandData) {
-    if (preg_match("/^@prod/", $commandData->input()->getArgument('destination'))) {
+    if (preg_match("/^@prod/", $commandData->input()->getArgument('target'))) {
       throw new \Exception(dt('Per !file, you may never rsync to the production site.', ['!file' => __FILE__]));
     }
   }


### PR DESCRIPTION
The 'destination' arguments for the sql:sync and core:rsync are now called 'target'.