### PR TITLE
WIP: Add setup wizard?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,14 @@
     },
     "autoload": {
         "classmap": [
-            "scripts/composer/ScriptHandler.php"
+            "scripts/composer/ScriptHandler.php",
+            "scripts/composer/Setup.php"
         ],
         "files": ["load.environment.php"]
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "setup": "DrupalProject\\composer\\Setup::setup",
         "pre-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],
@@ -56,6 +58,9 @@
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+        ],
+        "post-root-package-install": [
+            "@setup"
         ]
     },
     "extra": {

--- a/scripts/composer/Setup.php
+++ b/scripts/composer/Setup.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace DrupalProject\composer;
+
+use Composer\Json\JsonFile;
+use Composer\Script\Event;
+use Symfony\Component\Filesystem\Filesystem;
+
+class Setup {
+
+  public static function setup(Event $event) {
+    $jsonFile = new JsonFile($event->getComposer()
+      ->getConfig()
+      ->getConfigSource()
+      ->getName());
+    $config = $jsonFile->read();
+    $fs = new Filesystem();
+    $drupalRoot = $event->getIO()->ask('<info>Customize Drupal root path?</info> [<comment>web</comment>]? ', 'web');
+    if ($drupalRoot !== 'web') {
+      $drupalRoot = rtrim($drupalRoot, '/');
+      $gitIgnore = file_get_contents('.gitignore');
+      $gitIgnore = preg_replace('/' . preg_quote('web/', '/') . '/', $drupalRoot . '/', $gitIgnore);
+      if (isset($config['extra']['installer-paths'])) {
+        $installer_paths = [];
+        foreach ($config['extra']['installer-paths'] as $path => $spec) {
+          $newPath = preg_replace('/' . preg_quote('web/', '/') . '/', $drupalRoot . '/', $path);
+          $installer_paths[$newPath] = $spec;
+        }
+        $config['extra']['installer-paths'] = $installer_paths;
+      }
+      $fs->dumpFile('.gitignore', $gitIgnore);
+    }
+    if ($event->getIO()->askConfirmation('<info>Remove dotenv?</info> [<comment>y,N</comment>]? ', TRUE)) {
+      $fs->remove(['.env.example', 'load.environment.php']);
+      if (!empty($config['autoload']['files'])) {
+        $config['autoload']['files'] = array_diff($config['autoload']['files'], ['load.environment.php']);
+        if (empty($config['autoload']['files'])) {
+          unset($config['autoload']['files']);
+        }
+      }
+      unset($config['require']['vlucas/phpdotenv']);
+      unset($config['require-dev']['vlucas/phpdotenv']);
+    }
+    if ($event->getIO()->askConfirmation('<info>Remove drush?</info> [<comment>y,N</comment>]? ', FALSE)) {
+      unset($config['require']['drush/drush']);
+      unset($config['require-dev']['drush/drush']);
+    }
+    if ($event->getIO()->askConfirmation('<info>Remove drupal-console?</info> [<comment>y,N</comment>]? ', FALSE)) {
+      unset($config['require']['drupal/console']);
+      unset($config['require-dev']['drupal/console']);
+    }
+    if ($event->getIO()->askConfirmation('<info>Remove the installer and other scaffold files?</info> [<comment>y,N</comment>]? ', FALSE)) {
+      unset($config['scripts']['setup']);
+      $config['autoload']['classmap'] = array_diff($config['autoload']['classmap'], ['scripts/composer/Setup.php']);
+      $config['scripts']['post-root-package-install'] = array_diff($config['scripts']['post-root-package-install'], ['@setup']);
+      if (empty($config['scripts']['post-root-package-install'])) {
+        unset($config['scripts']['post-root-package-install']);
+      }
+      $fs->remove([
+        '.travis.yml',
+        'phpunit.xml.dist',
+        'scripts/composer/Setup.php',
+      ]);
+    }
+    $jsonFile->write($config);
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
I wrote a setup class, which provides some configuration options prior project initialization and deletes itself afterwards. This could be interesting for the composer initiative, or evaluator experience. We could add more features to this template without enforcing every feature. 

The code is not pretty, but it does the job.

Current features:

- Change drupal root? web => docroot
- Remove drupal-console / drush / dotenv
- Remove setup wizard itself
- Remove default .travis config and phpunit

Possible features:

- Configure dev env? Lando / ddev / etc.
- Add webflo/drupal-core-strict?

Command for evaluation:

```
composer create-project --repository '{"type": "git", "url": "git@github.com:webflo/drupal-project.git"}' drupal-composer/drupal-project my-project dev-setup -vvv
```

Related issues:

- https://github.com/drupal-composer/drupal-project/issues/379
- https://github.com/drupal-composer/drupal-project/issues/352
- https://github.com/drupal-composer/drupal-project/pull/317
- https://github.com/drupal-composer/drupal-project/pull/312