### PR TITLE
Bump minimum required composer-patches version to support default patch level

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,9 +71,6 @@
                 ".editorconfig": "../.editorconfig",
                 ".gitattributes": "../.gitattributes"
             }
-        },
-        "patchLevel": {
-            "drupal/core": "-p2"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "composer/installers": "^1.2",
-        "cweagans/composer-patches": "^1.6",
+        "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
         "drupal/core": "~8.5.3",
@@ -71,6 +71,9 @@
                 ".editorconfig": "../.editorconfig",
                 ".gitattributes": "../.gitattributes"
             }
+        },
+        "patchLevel": {
+            "drupal/core": "-p2"
         }
     }
 }


### PR DESCRIPTION
Also changed minimum required version of  cweagans/composer-patches to 1.6.5 because this is the version where patch level support gets introduced.

https://github.com/cweagans/composer-patches/releases/tag/1.6.5