### PR TITLE
Create a ../config/sync directory with correct permissions

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -58,6 +58,14 @@ class ScriptHandler {
       umask($oldmask);
       $event->getIO()->write("Create a sites/default/files directory with chmod 0777");
     }
+
+    // Create the config/sync directory (with chmod 0777) - ref CONFIG_SYNC_DIRECTORY above.
+    if (!$fs->exists($drupalFinder->getComposerRoot() . '/config/sync')) {
+      $oldmask = umask(0);
+      $fs->mkdir($drupalFinder->getComposerRoot() . '/config/sync', 0777);
+      umask($oldmask);
+      $event->getIO()->write("Create a ../config/sync directory with chmod 0777");
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #274 

I considered if the permissions should be set on the parent directory, but I think that should be left to decide for the user. (Please don't discuss - in this PR at least - the usage of 777 versus group write permissions. I just follow the choice already made for the files directory.)