### PR TITLE
Added "composer-exit-on-patch-failure": true option to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         ]
     },
     "extra": {
+        "composer-exit-on-patch-failure": true,
         "patchLevel": {
             "drupal/core": "-p2"
         },


### PR DESCRIPTION
By default, failed patches are skipped and a message will be shown.

If a patch cannot be applied (hunk failed, different line endings, etc.) I believe it would be useful to enforce throwing an error and to stop package installation/update immediately.