### PR TITLE
Add a composer command `drupal:upgrade` as an alias to upgrade Drupal.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,9 @@
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+        ],
+        "drupal:upgrade": [
+            "@composer update drupal/core webflo/drupal-core-require-dev symfony/* --with-dependencies"
         ]
     },
     "extra": {


### PR DESCRIPTION
I find myself always going back to the README.md for this, so I figured, why not add it as a command?

I've already added it to our fork of this: https://github.com/opendevshop/devshop-composer-template