### PR TITLE
Adding Notes about Composer Version Constraints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ If you use the default version constraint for `drupal/core` used in this project
 
 If you want the `composer update` command to automatically update minor versions, like from `8.5` to `8.6` automatically, set the version of `drupal/core` and `webflo/drupal-core-require-dev` to `~8.5`.
 
+Visit the [Composer Versions and Constraints documentation](https://getcomposer.org/doc/articles/versions.md) for more information.
+
 ## Generate composer.json from existing project
 
 With using [the "Composer Generate" drush extension](https://www.drupal.org/project/composer_generate)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Follow the steps below to update your core files.
 
 The `composer update` will only upgrade your packages within the "version constraints" specified in your `composer.json` file.
 
-If you use the default version constraint for `drupal/core` used in this project (`~8.5.3`), the `composer upgrade` command will only upgrade `drupal/core` within the `8.5.x` branch (for example to `8.5.4`)
+If you use the default version constraint for `drupal/core` used in this project (`~8.5.3`), the `composer upgrade` command will only upgrade `drupal/core` within the `8.5.x` branch (for example to `8.5.4`). It will _not_ upgrade drupal/core to `8.6.0` when it comes out, unless you change the version constraint.
 
 If you want the `composer update` command to automatically update minor versions, like from `8.5` to `8.6` automatically, set the version of `drupal/core` and `webflo/drupal-core-require-dev` to `~8.5`.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Follow the steps below to update your core files.
    keeping all of your modifications at the beginning or end of the file is a 
    good strategy to keep merges easy.
 
+### Notes about Composer Version Constraints
+
+The `composer update` will only upgrade your packages within the "version constraints" specified in your `composer.json` file.
+
+If you use the default version constraint for `drupal/core` used in this project (`~8.5.3`), the `composer upgrade` command will only upgrade `drupal/core` within the `8.5.x` branch (for example to `8.5.4`)
+
+If you want the `composer update` command to automatically update minor versions, like from `8.5` to `8.6` automatically, set the version of `drupal/core` and `webflo/drupal-core-require-dev` to `~8.5`.
+
 ## Generate composer.json from existing project
 
 With using [the "Composer Generate" drush extension](https://www.drupal.org/project/composer_generate)


### PR DESCRIPTION
This explains that to upgrade drupal with the `composer update` command you have to change the `drupal/core` version constraint.