### PR TITLE
Documentation clarification when using local patch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ section of composer.json:
     }
 }
 ```
+
+One thing to worth noting with local patch files, it appears the patch will only be detected if it has a .txt file extension.
+
 ### How do I switch from packagist.drupal-composer.org to packages.drupal.org?
 
 Follow the instructions in the [documentation on drupal.org](https://www.drupal.org/docs/develop/using-composer/using-packagesdrupalorg).


### PR DESCRIPTION
This change would have really benefitted me and saved me a lot of time today, so I think it might be worth mentioning the in the documentation/README. You can see the fix being referenced here: https://github.com/cweagans/composer-patches/issues/146