### PR TITLE
Use symfony-clean-tags plugin to improve performance and resolve install/update errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "drupal/console": "^1.0.2",
         "drupal/core": "^8.6.0",
         "drush/drush": "^9.0.0",
+        "rubenrua/symfony-clean-tags-composer-plugin": "^1.0",
         "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.0.0",
-        "webmozart/path-util": "^2.3",
-        "zaporylie/composer-drupal-optimizations": "^1.0"
+        "webmozart/path-util": "^2.3"
     },
     "require-dev": {
         "webflo/drupal-core-require-dev": "^8.6.0"
@@ -77,6 +77,9 @@
                 ".editorconfig": "../.editorconfig",
                 ".gitattributes": "../.gitattributes"
             }
+        },
+        "symfony": {
+            "require": "3.4.*"
         }
     }
 }


### PR DESCRIPTION
Fixes #439  
--------
Having `zaporylie/composer-drupal-optimizations` in the root `composer.json` appears to cause issues with autoloading classes in the correct place when using the `installers` and `composer-merge` plugins and also [hard codes the symfony version constraint](https://github.com/zaporylie/composer-drupal-optimizations/blob/master/src/Cache.php#L14). Hard coding this constraint may cause issues when updating core and other dependent packages unless `zaporylie/composer-drupal-optimizations` is actively maintained. Swapping out composer-drupal-optimizations for the symfony-clean-tags-composer-plugin will allow for the same performance improvements without the additional maintenance and update issues. Benchmarks (below) show that this plugin might even perform slightly better. 

Changes proposed:
---------
Use `rubenrua/symfony-clean-tags-composer-plugin` rather than `zaporylie/composer-drupal-optimizations` 

Steps to reproduce:
-----------
create a new drupal-project and atempt to update core or another package dependent on core. Observe the "Could not scan for classes" errors:
 
```
~/sites/some-dir
❯ composer update drupal/core
Could not scan for classes inside "docroot/core/lib/Drupal.php" which does not appear to be a file nor a folder
```

### Benchmarks: 

### *with zaporylie/composer-drupal-optimizations* [240.5MB/6.11s]
```
~/sites/some-dir 32s
❯ composer update nothing --profile -v
[11.6MB/0.31s] Loading composer repositories with package information
[240.5MB/6.11s] Memory usage: 240.51MB (peak: 307.38MB), time: 6.11s
```
### *drupal-project without optimization plugins* [321.1MB/16.81s]

```
~/sites/some-dir 12s
❯ composer remove zaporylie/composer-drupal-optimizations
Package operations: 0 installs, 0 updates, 1 removal
  - Removing zaporylie/composer-drupal-optimizations (1.0.2)
Writing lock file
Generating autoload files

~/sites/some-dir 8s
❯ composer update nothing --profile -v
[11.4MB/0.07s] Loading composer repositories with package information
[321.1MB/16.81s] Memory usage: 321.11MB (peak: 1115.54MB), time: 16.81s

```

### With rubenrua/symfony-clean-tags-composer-plugin [220.1MB/2.82s]

```
~/sites/some-dir 18s
❯ composer require rubenrua/symfony-clean-tags-composer-plugin

~/sites/some-dir 21s
❯ COMPOSER_MEMORY_LIMIT=-1 composer config extra.symfony.require 3.4.*

~/sites/some-dir
❯ composer update nothing --profile -v
[9.7MB/0.06s] > pre-update-cmd: DrupalProject\composer\ScriptHandler::checkComposerVersion
[11.5MB/0.06s] Loading composer repositories with package information
[154.5MB/1.13s] Restricting packages listed in "symfony/symfony" to "3.4.0"
[243.7MB/2.60s] Dependency resolution completed in 0.022 seconds
[244.1MB/2.61s] Analyzed 7418 packages to resolve dependencies
[244.1MB/2.61s] Analyzed 36401 rules to resolve dependencies
[220.1MB/2.82s] Memory usage: 220.08MB (peak: 245.9MB), time: 2.82s
```
