### PR TITLE
Quote wildcards to avoid issues in some shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ new release of Drupal core.
 
 Follow the steps below to update your core files.
 
-1. Run `composer update drupal/core webflo/drupal-core-require-dev symfony/* --with-dependencies` to update Drupal Core and its dependencies.
+1. Run `composer update drupal/core webflo/drupal-core-require-dev "symfony/*" --with-dependencies` to update Drupal Core and its dependencies.
 1. Run `git diff` to determine if any of the scaffolding files have changed. 
    Review the files for any changes and restore any customizations to 
   `.htaccess` or `robots.txt`.


### PR DESCRIPTION
Without quote this kind of command fail on Zsh or fishshell with default configuration.