### PR TITLE
Fix issue with ignoring unnecessary folders (e.g /web/sites/all/modules/custom)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /web/sites/all/libraries/
 
 # Ignore Drupal 7 core files.
-/web/*
+/web/
 !/web/*/
 /web/includes/
 /web/misc/


### PR DESCRIPTION
`.gitignore` rules says: 

> Appending a slash indicates the pattern is a directory. The entire contents of any directory in the repository matching that name – including all of its files and subdirectories – will be ignored


so, it means we are safe here to use just `/web/` instead of `/web/*`.

the main reason of this PR when I use `/web/*`, my folder (e.g `/web/sites/all/modules/custom` will be also ignored but it should not be).