### PR TITLE
Update `composer.json` in order to allow development versions instead to set "minimum-stability"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for your setup.
 After that you can create the project:
 
 ```
-composer create-project drupal-composer/drupal-project:8.x-dev some-dir --no-interaction
+composer create-project drupal-composer/drupal-project:^8.0@dev some-dir --no-interaction
 ```
 
 With `composer require ...` you can download new dependencies to your
@@ -28,7 +28,7 @@ installation.
 
 ```
 cd some-dir
-composer require drupal/devel:~1.0
+composer require drupal/devel:^1.0
 ```
 
 The `composer create-project` command passes ownership of all files to the

--- a/composer.json
+++ b/composer.json
@@ -16,26 +16,28 @@
         }
     ],
     "require": {
-        "php": ">=7.0.8",
+        "php": "^7.0.8",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "^8.7.0",
-        "drush/drush": "^9.0.0",
+        "drupal/core": "^8.7",
+        "drush/drush": "^9",
         "vlucas/phpdotenv": "^2.4",
-        "webflo/drupal-finder": "^1.0.0",
+        "webflo/drupal-finder": "^1",
         "webmozart/path-util": "^2.3",
-        "zaporylie/composer-drupal-optimizations": "^1.0"
+        "zaporylie/composer-drupal-optimizations": "^1"
     },
     "require-dev": {
-        "webflo/drupal-core-require-dev": "^8.7.0"
+        "behat/mink": "^1.7@dev",
+        "behat/mink-selenium2-driver": "^1.3@dev",
+        "friendsofphp/php-cs-fixer": "^2.15",
+        "phpunit/phpunit": "^6.5",
+        "webflo/drupal-core-require-dev": "^8.7"
     },
     "conflict": {
         "drupal/drupal": "*"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
Update `composer.json` in order to whitelist (with [stability flags](https://getcomposer.org/doc/04-schema.md#package-links)) development versions instead to set "minimum-stability".

## The problem with the current setup (using "dev" as "minimum-stability"):
- `my-project` requires `package-A:^2.0`, which has a stable release;
- users perform `composer update`
- `package-A` is resolved to their last available 2 major (stable) version, let's say `2.7.4`;
- `package-A` requires `package-B:^1.0`, which has a stable release;
- `package-B` is resolved to their last available 1 major (stable) version, let's say `1.0.0`;
---
Until here, everything should be fine, since `my-project` knows that all the installed packages are stable. Let's see the following:

- in the PATCH version `2.7.5` the `package-A` decides to change their requirement from `package-B:^1.0` to `package-B:2.0-dev`, which **is not a stable** release;
- users perform `composer update`
- `package-A` is resolved to their last available 2 major (stable) version (`2.7.5`);
- `package-B` is resolved to their last available 2 major (**unstable**) version (2.0-dev);
---
At this point, the users which own the responsibility under `my-project` were installed silently an unstable version of a package which can potentially break some existing feature or behavior in their project.
With the proposed changes, if the users want to use the `2.7.5` version from `package-A`, they will be restricted to install the unstable version from package `package-B`, at least if they decide under their own risk and responsibility to trust on that package, whitelisting it until a stable release will be available from what is required from `package-A`.

