### PR TITLE
#509: ignore console/language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /web/themes/contrib/
 /web/profiles/contrib/
 /web/libraries/
+/console/language/
 
 # Ignore sensitive information
 /web/sites/*/settings.php


### PR DESCRIPTION
This is needed after composer-installers 1.7.0, as per https://github.com/hechoendrupal/drupal-console-core/pull/364#issuecomment-523331104.