### PR TITLE
Add installer paths for drupal custom modules and themes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,9 @@
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/Commands/{$name}": ["type:drupal-drush"]
+            "drush/Commands/{$name}": ["type:drupal-drush"],
+            "web/modules/custom/{$name}": ["type:drupal-custom-module"],
+            "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
         "drupal-scaffold": {
             "initial": {


### PR DESCRIPTION
Add install paths for types drupal-custom-modules and drupal-custom-themes, otherwise they are installed by composer/installers in /themes/custom/{$name} or /modules/custom/{$name}. 

Use case: 
composer create-project drupal-composer/drupal-project:8.x-dev some-dir --no-interaction
composer require vendor/drupal-install-profile 

If the drupal-install-profile has a composer.json file that requires any custom modules or themes (ie. "type": "drupal-custom-module" or "type": "drupal-custom-theme", they are not placed in the /web directory but installed outside the web root. Additionally, you cannot use "extra" data within a nested composer.json file if you want to set the installer-path to the /web directory. 