### PR TITLE
Removing  "symfony/*" from update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ new release of Drupal core.
 
 Follow the steps below to update your core files.
 
-1. Run `composer update drupal/core webflo/drupal-core-require-dev "symfony/*" --with-dependencies` to update Drupal Core and its dependencies.
+1. Run `composer update drupal/core webflo/drupal-core-require-dev --with-dependencies` to update Drupal Core and its dependencies.
 1. Run `git diff` to determine if any of the scaffolding files have changed.
    Review the files for any changes and restore any customizations to
   `.htaccess` or `robots.txt`.


### PR DESCRIPTION
 "symfony/\*" was added to the update command because of a specific problem when upgrading Drupal 8.4.4 (because of a dependency in Drupal Console or something). As discussed in #362 next time the problem can be something completely different. Keeping "symfony/\*" doesn't make any sense to me, but I might be wrong.