### PR TITLE
Add 'contrib' to Drush commandfile installer path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/Commands/{$name}": ["type:drupal-drush"]
+            "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
         },
         "drupal-scaffold": {
             "initial": {


### PR DESCRIPTION
For consistency, add 'contrib' to Drush commandfile installer path. This opens the way for folks to add site-specific commandfiles in 'custom'.

c.f. https://github.com/pantheon-systems/example-drops-8-composer/blob/2.0.0/composer.json#L89