### PR TITLE
Do not use a trailing slash in web root

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         },
         "drupal-scaffold": {
             "locations": {
-                "web-root": "web/"
+                "web-root": "./web"
             }
         },
         "installer-paths": {


### PR DESCRIPTION
Athough technically the web root can have any value, the trailing slash confused me when I used drupal-project and compared it with the documentation of core-composer-scaffold. In the code implementation its value is used in the `[web-root]` placeholder. Drupal core uses the placeholder followed by a trailing slash: e.g. `[web-root]/robots.txt`. 

Some more references:
- core-composer-scaffold documentation defines it in an example as: `"web-root": "./docroot"`
- The code that performs and documents the replacement: ScaffoldFilePath::destinationPath in https://github.com/drupal/core-composer-scaffold/blob/8.8.x/ScaffoldOptions.php