### PR TITLE
drupal-composer/drupal-project has [not] been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Composer template for Drupal projects
+# Composer template for Drupal projects (deprecated)
+
+**Deprecated:** Using drupal-composer/drupal-project has been deprecated as of Drupal 8.8.0. Please use the [officially supported drupal/recommended-project](https://www.drupal.org/docs/develop/using-composer/using-composer-to-install-drupal-and-manage-dependencies) instead, according to the instructions above.
 
 [![Build Status](https://travis-ci.org/drupal-composer/drupal-project.svg?branch=8.x)](https://travis-ci.org/drupal-composer/drupal-project)
 


### PR DESCRIPTION
As of the release of Drupal 8.8.0 - the recommend composer template changed from drupal-composer/drupal-project to the officially supported: drupal/recommended-project

I think this should be indicated in the readme.