### PR TITLE
[#549] Update ScriptHandler.php to check for symlinks before creating files directory

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -52,7 +52,7 @@ class ScriptHandler {
     }
 
     // Create the files directory with chmod 0777
-    if (!$fs->exists($drupalRoot . '/sites/default/files')) {
+    if (!$fs->exists($drupalRoot . '/sites/default/files') && !is_link($drupalRoot . '/sites/default/files')) {
       $oldmask = umask(0);
       $fs->mkdir($drupalRoot . '/sites/default/files', 0777);
       umask($oldmask);


### PR DESCRIPTION
Closes #549

When using drupal inside a docker container it can be useful to make the sites/default/files directory a symlink instead. For example here in the wodby documentation https://wodby.com/docs/stacks/drupal/#files_1

I propose adding a check to is_link to prevent errors caused by $fs->exists not handling symlinks.