### PR TITLE
Issue #562: Removed PHP 7.0 and 7.1 jobs from builds since EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 install:
   - composer --verbose validate
-  - composer --verbose install
+  - COMPOSER_MEMORY_LIMIT=-1 composer --verbose install
 
 script:
   - if [[ $RELEASE = dev ]]; then composer --verbose remove --no-update drupal/console; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   matrix:
     - RELEASE=stable COMPOSER_CHANNEL=stable
     - RELEASE=dev COMPOSER_CHANNEL=stable
-    - RELEASE=stable COMPOSER_CHANNEL=snapshot
+    # - RELEASE=stable COMPOSER_CHANNEL=snapshot
 
 before_install:
   - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini


### PR DESCRIPTION
Relates to: https://github.com/drupal-composer/drupal-project/issues/562