### PR TITLE
Update drupal-composer/preseve-paths to enable PHP 7.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "composer/installers": "^1.2",
         "composer/semver": "^1.4",
         "cweagans/composer-patches": "^1.6.5",
-        "drupal-composer/preserve-paths": "^0.1",
+        "drupal-composer/preserve-paths": "dev-master#4c5f62",
         "drupal/composer_autoloader": "^1.0",
         "drupal/drupal": "^7.62",
         "drush/drush": "^8.0",


### PR DESCRIPTION
Right now, if you run the documented command to create a new project (or "composer install" on an existing stack) using PHP-CLI 7.4, it will fail: 

```shell
$ composer create-project drupal-composer/drupal-project:7.x-dev drupal-composer-7
Creating a "drupal-composer/drupal-project:7.x-dev" project at "./drupal-composer-7"
Installing drupal-composer/drupal-project (7.x-dev 267d7fe14c74af8c04fc84c7f483434eca35ef90)
  - Installing drupal-composer/drupal-project (7.x-dev 267d7fe): Cloning 267d7fe14c from cache
Created project in /home/jon/Projects/drupal-composer-7
> DrupalProject\composer\ScriptHandler::checkComposerVersion
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 32 installs, 0 updates, 0 removals
  - Installing composer/installers (v1.9.0): Loading from cache
  - Installing cweagans/composer-patches (1.6.7): Loading from cache
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Installing drupal-composer/preserve-paths (0.1.5): Loading from cache

                                                       
  [ErrorException]                                     
  Trying to access array offset on value of type null  
                                                       
```

The fix is already in `drupal-composer/preserve-paths` but not in a tagged release.

This PR is initially requiring the SHA with the fix, but if we can get a new tag for `drupal-composer/preserve-paths` the PR could continue and update to use the new version.

See:
- https://github.com/drupal-composer/preserve-paths/issues/28 (Original issue and fix)
- https://github.com/drupal-composer/preserve-paths/issues/33  (Steps to Reproduce)