### PR TITLE
Update .env.example to reflect latest version of vlucas/phpdotenv.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,14 +6,14 @@
 # like so:
 #
 # $databases['default']['default'] = [
-#   'database' => getenv('MYSQL_DATABASE'),
+#   'database' => $_ENV['MYSQL_DATABASE'],
 #   'driver' => 'mysql',
-#   'host' => getenv('MYSQL_HOSTNAME'),
+#   'host' => $_ENV['MYSQL_HOSTNAME'],
 #   'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-#   'password' => getenv('MYSQL_PASSWORD'),
-#   'port' => getenv('MYSQL_PORT'),
+#   'password' => $_ENV['MYSQL_PASSWORD'],
+#   'port' => $_ENV['MYSQL_PORT'],
 #   'prefix' => '',
-#   'username' => getenv('MYSQL_USER'),
+#   'username' => $_ENV['MYSQL_USER'],
 # ];
 #
 # Uncomment and populate as needed.


### PR DESCRIPTION
The latest version of [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv) doesn't support `getenv()` in `Dotenv::createImmutable()`; you need to use one of the superglobals. This updates `.env.example` to reflect proper usage.