### PR TITLE
Allow getenv() to work again with vlucas/phpdotenv 5.x

### DIFF
--- a/load.environment.php
+++ b/load.environment.php
@@ -11,5 +11,5 @@ use Dotenv\Exception\InvalidPathException;
 /**
  * Load any .env file. See /.env.example.
  */
-$dotenv = Dotenv::createImmutable(__DIR__);
-$dotenv->safeLoad();
+$dotenv = Dotenv::createUnsafeImmutable(__DIR__);
+$dotenv->load();

--- a/load.environment.php
+++ b/load.environment.php
@@ -10,6 +10,9 @@ use Dotenv\Exception\InvalidPathException;
 
 /**
  * Load any .env file. See /.env.example.
+ *
+ * Drupal has no official method for loading environment variables and uses 
+ * getenv() in some places.
  */
 $dotenv = Dotenv::createUnsafeImmutable(__DIR__);
 $dotenv->load();


### PR DESCRIPTION
https://github.com/vlucas/phpdotenv no longer works with getenv() by default in 5.x, you need to call explicitly `Dotenv::createUnsafeImmutable` to have those calls work.  There are may places that use `getenv()` calls still including Drush.
```
-$dotenv = Dotenv::createImmutable(__DIR__);
+$dotenv = Dotenv::createUnsafeImmutable(__DIR__);
```