### PR TITLE
Safe-load .env only if exists to prevent fatal error during site install.

### DIFF
--- a/load.environment.php
+++ b/load.environment.php
@@ -6,13 +6,12 @@
  */
 
 use Dotenv\Dotenv;
-use Dotenv\Exception\InvalidPathException;
 
 /**
  * Load any .env file. See /.env.example.
  *
- * Drupal has no official method for loading environment variables and uses 
+ * Drupal has no official method for loading environment variables and uses
  * getenv() in some places.
  */
 $dotenv = Dotenv::createUnsafeImmutable(__DIR__);
-$dotenv->load();
+$dotenv->safeLoad();


### PR DESCRIPTION
Seems #584 accidentally swapped safe-loading (only if exists) the .env file with a simple `load()` which now causes a fatal on `drush site:install`. Let's switch `load()` back to `safeLoad()`.

> ```bash
> $ drush -y si --account-name=admin --account-pass=admin
> 
> Fatal error: Uncaught Dotenv\Exception\InvalidPathException: Unable to read any of the environment file(s) at [/Users/leymannx/Sites/d9/.env]. in /Users/leymannx/Sites/d9/vendor/vlucas/phpdotenv/src/Store/FileStore.php:68
> Stack trace:
> #0 /Users/leymannx/Sites/d9/vendor/vlucas/phpdotenv/src/Dotenv.php(222): Dotenv\Store\FileStore->read()
> #1 /Users/leymannx/Sites/d9/load.environment.php(18): Dotenv\Dotenv->load()
> #2 /Users/leymannx/Sites/d9/vendor/composer/autoload_real.php(75): require('/Users/leymannx...')
> #3 /Users/leymannx/Sites/d9/vendor/composer/autoload_real.php(65): composerRequire62f8ceaa89421c6aefe473318c51d739('d511210698f02d8...', '/Users/leymannx...')
> #4 /Users/leymannx/Sites/d9/vendor/autoload.php(7): ComposerAutoloaderInit62f8ceaa89421c6aefe473318c51d739::getLoader()
> #5 /Users/leymannx/Sites/d9/vendor/drush/drush/drush.php(56): include_once('/Users/leymannx...')
> #6 /Users/leymannx/Sites/d9/vendor/drush/drush/includes/preflight.inc(18): require('/Users/leymannx...')
> #7 phar:///usr/local/bin/drush/bin/drush.php in /Users/leymannx/Sites/d9/vendor/vlucas/phpdotenv/src/Store/FileStore.php on line 68
> ```