### PR TITLE
Allow Dotenv implementation in load.environment.php to be backwards compatible.

### DIFF
--- a/load.environment.php
+++ b/load.environment.php
@@ -17,6 +17,7 @@ use Dotenv\Dotenv;
  */
 if (method_exists('Dotenv', 'createUnsafeImmutable')) {
   $dotenv = Dotenv::createUnsafeImmutable(__DIR__);
+}
 elseif (method_exists('Dotenv', 'createImmutable')) {
   $dotenv = Dotenv::createImmutable(__DIR__);
 }  

--- a/load.environment.php
+++ b/load.environment.php
@@ -12,6 +12,12 @@ use Dotenv\Dotenv;
  *
  * Drupal has no official method for loading environment variables and uses
  * getenv() in some places.
+ * 
+ * Check for the method to ensure backward compatibility.
  */
-$dotenv = Dotenv::createUnsafeImmutable(__DIR__);
+if (method_exists('Dotenv', 'createUnsafeImmutable')) {
+  $dotenv = Dotenv::createUnsafeImmutable(__DIR__);
+elseif (method_exists('Dotenv', 'createImmutable')) {
+  $dotenv = Dotenv::createImmutable(__DIR__);
+}  
 $dotenv->safeLoad();


### PR DESCRIPTION
I am running an automated upgrade as a test site for some Ansible I am developing using this repo.

Upgrading a site in place hits a snag when the autoloader includes load.environment.php (when upgrading from Drupal 8 to 9 only).

You can see in these logs that the method isn't found: https://github.com/opendevshop/devshop.platform/runs/3693762573?check_suite_focus=true#step:9:3504

>   PHP Fatal error:  Uncaught Error: Call to undefined method Dotenv\Dotenv::createUnsafeImmutable() in /var/platform/apps/composerupgrade/d8localcomputer/load.environment.php:16


I'm not quite sure if this should be merged into the main project or not, but at the very least, this branch will exist for testing purposes.

Feedback welcome.