### PR TITLE
Increased drush version to 12.4.3 (Drush versions below 12.4.3 are incompatible with Drupal 10.2.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^10.0.0",
         "drupal/core-recommended": "^10.0.0",
-        "drush/drush": "^11.4.0",
+        "drush/drush": "^12.4.3",
         "vlucas/phpdotenv": "^5.1",
         "webflo/drupal-finder": "^1.2"
     },


### PR DESCRIPTION
I was unable to upgrade to Drupal 10.2, because drush versions below 12.4.3 are incompatible with Drupal 10.2.x.

This was discussed here https://www.drupal.org/project/drupal/issues/3402955 and it's also mentioned in the 10.2.0 release note https://www.drupal.org/project/drupal/releases/10.2.0