### PR TITLE
Added php-http/discovery to "allow-plugins" for D10.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
+            "php-http/discovery": true,
             "phpstan/extension-installer": true
         }
     },


### PR DESCRIPTION
When https://github.com/drupal-composer/drupal-project/pull/631 was merged, this unblocked the installation of Drupal 10.2
However, D10.2 requires that `"php-http/discovery"` exists in `"allow-plugins"` section of `composer.json`.