### PR TITLE
Replace Drush annotations with attributes

### DIFF
--- a/drush/Commands/PolicyCommands.php
+++ b/drush/Commands/PolicyCommands.php
@@ -3,6 +3,10 @@
 namespace Drush\Commands;
 
 use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Drush\Attributes\Hook;
+use Drush\Commands\core\RsyncCommands;
+use Drush\Commands\sql\SqlSyncCommands;
 
 /**
  * Edit this file to reflect your organization's needs.
@@ -13,10 +17,9 @@ class PolicyCommands extends DrushCommands {
    * Prevent catastrophic braino. Note that this file has to be local to the
    * machine that initiates the sql:sync command.
    *
-   * @hook validate sql:sync
-   *
    * @throws \Exception
    */
+  #[Hook(type: HookManager::ARGUMENT_VALIDATOR, target: SqlSyncCommands::SYNC)]
   public function sqlSyncValidate(CommandData $commandData) {
     if ($commandData->input()->getArgument('target') == '@prod') {
       throw new \Exception(dt('Per !file, you may never overwrite the production database.', ['!file' => __FILE__]));
@@ -26,10 +29,9 @@ class PolicyCommands extends DrushCommands {
   /**
    * Limit rsync operations to production site.
    *
-   * @hook validate core:rsync
-   *
    * @throws \Exception
    */
+  #[Hook(type: HookManager::ARGUMENT_VALIDATOR, target: RsyncCommands::RSYNC)]
   public function rsyncValidate(CommandData $commandData) {
     if (preg_match("/^@prod/", $commandData->input()->getArgument('target'))) {
       throw new \Exception(dt('Per !file, you may never rsync to the production site.', ['!file' => __FILE__]));


### PR DESCRIPTION
These are available as of [Drush 12.0.0](https://github.com/drush-ops/drush/releases/tag/12.0.0). Given that a higher version is now required in the `composer.json` of this template, this should be the preferred way of referencing hooks.