### PR TITLE
Update to use new Drupal Finder (Composer Runtime) API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/core-recommended": "^10.2.0",
         "drush/drush": "^12.4.3",
         "vlucas/phpdotenv": "^5.1",
-        "webflo/drupal-finder": "^1.2"
+        "webflo/drupal-finder": "^1.3"
     },
     "require-dev": {
         "drupal/core-dev": "^10.2.0",

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -11,7 +11,7 @@ use Composer\Script\Event;
 use Composer\Semver\Comparator;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Site\SettingsEditor;
-use DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
@@ -19,9 +19,17 @@ class ScriptHandler {
 
   public static function createRequiredFiles(Event $event) {
     $fs = new Filesystem();
-    $drupalFinder = new DrupalFinder();
-    $drupalFinder->locateRoot(getcwd());
+    $drupalFinder = new DrupalFinderComposerRuntime();
     $drupalRoot = $drupalFinder->getDrupalRoot();
+
+    // If Drupal root was not found, exit.
+    if (is_null($drupalRoot)) {
+      $io = $event->getIO();
+      $io->writeError(
+        '<error>Drupal root could not be detected.</error>',
+      );
+      exit(1);
+    }
 
     $dirs = [
       'modules',


### PR DESCRIPTION
Drupal Finder has been revamped to use the Composer Runtime API, which makes it much simpler in how it operates. This PR updates the composer script handler to use this new Drupal Finder API. It also adds an additional panic exit in case the root cannot be found.

See also https://github.com/webflo/drupal-finder/releases/tag/1.3.0.

*Edit:* this requires some kind of additional work for new installations, given that the `Path::makeRelative` call seems to be failing on new installations, supposedly due to `getComposerRoot` returning `null` on fresh installations. I'm not sure yet on the fix that is required here (or maybe upstream?). A repeated `composer install` run seems to fix the issues.